### PR TITLE
Fix toggle initialization failing

### DIFF
--- a/EasySettings/TemplateManager.cs
+++ b/EasySettings/TemplateManager.cs
@@ -181,7 +181,7 @@ internal static class TemplateManager
     {
         Transform[] tabContents = [manager._videoTabContent, manager._audioTabContent, manager._inputTabContent, manager._networkTabContent];
 
-        Toggle toggle = manager._fullScreenToggle;
+        Toggle toggle = manager._jiggleBonesToggle;
 
         if (!Utility.TryGetElementRoot(tabContents, toggle.transform, out Transform root)) return null;
 


### PR DESCRIPTION
- Use jiggle bones toggle to initialize the toggle template instead of the fullscreen one since it changed.