### PR TITLE
feature: add TextField support

### DIFF
--- a/EasySettings/Elements/TextField.cs
+++ b/EasySettings/Elements/TextField.cs
@@ -1,0 +1,32 @@
+﻿using UnityEngine.Events;
+using UnityEngine.UI;
+
+namespace Nessie.ATLYSS.EasySettings.UIElements
+{
+    public class AtlyssTextField : BaseAtlyssLabelElement, IValueElement
+    {
+        public InputField InputField;
+        public Text Placeholder;
+        public UnityEvent<string> OnValueChanged { get; } = new();
+
+        public string AppliedValue { get; private set; }
+
+        public void Initialize()
+        {
+            Label.text = "Text Field";
+            Placeholder.text = "Placeholder";
+
+            InputField.onEndEdit.RemoveAllListeners();
+            InputField.onEndEdit.AddListener(ValueChanged);
+            InputField.text = AppliedValue;
+        }
+
+        public void SetValue(string value) => InputField.text = value;
+
+        public void Apply() => AppliedValue = InputField.text;
+
+        public void Revert() => InputField.text = AppliedValue;
+
+        private void ValueChanged(string newValue) => OnValueChanged.Invoke(newValue);
+    }
+}

--- a/EasySettings/Elements/TextField.cs
+++ b/EasySettings/Elements/TextField.cs
@@ -5,23 +5,47 @@ namespace Nessie.ATLYSS.EasySettings.UIElements
 {
     public class AtlyssTextField : BaseAtlyssLabelElement, IValueElement
     {
-        public InputField InputField;
+        private InputField _inputField;
+        public InputField InputField
+        {
+            get => _inputField;
+            set
+            {
+                if (_inputField != null) _inputField.onEndEdit.RemoveListener(ValueChanged);
+
+                _inputField = value;
+
+                if (_inputField != null)
+                {
+                    _inputField.onEndEdit.AddListener(ValueChanged);
+                    _inputField.text = AppliedValue;
+                }
+            }
+        }
+
         public Text Placeholder;
         public UnityEvent<string> OnValueChanged { get; } = new();
 
-        public string AppliedValue { get; private set; }
+        public string AppliedValue { get; private set; } = string.Empty;
 
         public void Initialize()
         {
-            Label.text = "Text Field";
-            Placeholder.text = "Placeholder";
+            LabelText = "Text Field";
+            if (Placeholder != null)
+                Placeholder.text = "Text..";
 
-            InputField.onEndEdit.RemoveAllListeners();
-            InputField.onEndEdit.AddListener(ValueChanged);
-            InputField.text = AppliedValue;
+            if (InputField != null)
+            {
+                InputField.onEndEdit.RemoveListener(ValueChanged);
+                InputField.onEndEdit.AddListener(ValueChanged);
+                InputField.text = AppliedValue;
+            }
         }
 
-        public void SetValue(string value) => InputField.text = value;
+        public void SetValue(string value)
+        {
+            if (InputField != null) InputField.text = value;
+        }
 
         public void Apply() => AppliedValue = InputField.text;
 

--- a/EasySettings/Elements/TextField.cs
+++ b/EasySettings/Elements/TextField.cs
@@ -31,8 +31,6 @@ namespace Nessie.ATLYSS.EasySettings.UIElements
         public void Initialize()
         {
             LabelText = "Text Field";
-            if (Placeholder != null)
-                Placeholder.text = "Text..";
 
             if (InputField != null)
             {

--- a/EasySettings/SettingsTab.cs
+++ b/EasySettings/SettingsTab.cs
@@ -335,22 +335,24 @@ public class SettingsTab
         manager.keyBindButtons = manager.keyBindButtons.AddToArray(keyButton);
     }
 
-    public AtlyssTextField AddTextField(ConfigEntry<string> config, string placeholder = "Placeholder") => AddTextField(config.Definition.Key, config, placeholder);
+    const string placeholderDefaultText = "Text..";
 
-    public AtlyssTextField AddTextField(string label, ConfigEntry<string> config, string placeholder = "Placeholder")
+    public AtlyssTextField AddTextField(ConfigEntry<string> config, string placeholder = placeholderDefaultText) => AddTextField(config.Definition.Key, config, placeholder);
+
+    public AtlyssTextField AddTextField(string label, ConfigEntry<string> config, string placeholder = placeholderDefaultText)
     {
         AtlyssTextField element = AddTextField(label, config.Value, placeholder);
         element.OnValueChanged.AddListener(newValue => { config.Value = newValue; });
         return element;
     }
 
-    public AtlyssTextField AddTextField(string label, string value = "", string placeholder = "Placeholder")
+    public AtlyssTextField AddTextField(string label, string value = "", string placeholder = placeholderDefaultText)
     {
         AtlyssTextField element = TemplateManager.CreateTextField(Content);
         Settings.OnCloseSettings.AddListener(() => element.Revert());
         Settings.OnApplySettings.AddListener(() => element.Apply());
 
-        element.Label.text = label;
+        element.LabelText = label;
 
         if (element.Placeholder != null)
             element.Placeholder.text = placeholder;

--- a/EasySettings/SettingsTab.cs
+++ b/EasySettings/SettingsTab.cs
@@ -15,6 +15,7 @@ public class SettingsTab
 {
     private const float DEFAULT_SLIDER_MIN = 0f;
     private const float DEFAULT_SLIDER_MAX = 1f;
+    private const string PLACEHOLDER_DEFAULT_TEXT = "Text...";
 
     public AtlyssTabButton TabButton;
     public MenuElement Element;
@@ -335,18 +336,16 @@ public class SettingsTab
         manager.keyBindButtons = manager.keyBindButtons.AddToArray(keyButton);
     }
 
-    const string placeholderDefaultText = "Text..";
+    public AtlyssTextField AddTextField(ConfigEntry<string> config, string placeholder = PLACEHOLDER_DEFAULT_TEXT) => AddTextField(config.Definition.Key, config, placeholder);
 
-    public AtlyssTextField AddTextField(ConfigEntry<string> config, string placeholder = placeholderDefaultText) => AddTextField(config.Definition.Key, config, placeholder);
-
-    public AtlyssTextField AddTextField(string label, ConfigEntry<string> config, string placeholder = placeholderDefaultText)
+    public AtlyssTextField AddTextField(string label, ConfigEntry<string> config, string placeholder = PLACEHOLDER_DEFAULT_TEXT)
     {
         AtlyssTextField element = AddTextField(label, config.Value, placeholder);
         element.OnValueChanged.AddListener(newValue => { config.Value = newValue; });
         return element;
     }
 
-    public AtlyssTextField AddTextField(string label, string value = "", string placeholder = placeholderDefaultText)
+    public AtlyssTextField AddTextField(string label, string value = "", string placeholder = PLACEHOLDER_DEFAULT_TEXT)
     {
         AtlyssTextField element = TemplateManager.CreateTextField(Content);
         Settings.OnCloseSettings.AddListener(() => element.Revert());

--- a/EasySettings/SettingsTab.cs
+++ b/EasySettings/SettingsTab.cs
@@ -335,6 +335,34 @@ public class SettingsTab
         manager.keyBindButtons = manager.keyBindButtons.AddToArray(keyButton);
     }
 
+    public AtlyssTextField AddTextField(ConfigEntry<string> config, string placeholder = "Placeholder") => AddTextField(config.Definition.Key, config, placeholder);
+
+    public AtlyssTextField AddTextField(string label, ConfigEntry<string> config, string placeholder = "Placeholder")
+    {
+        AtlyssTextField element = AddTextField(label, config.Value, placeholder);
+        element.OnValueChanged.AddListener(newValue => { config.Value = newValue; });
+        return element;
+    }
+
+    public AtlyssTextField AddTextField(string label, string value = "", string placeholder = "Placeholder")
+    {
+        AtlyssTextField element = TemplateManager.CreateTextField(Content);
+        Settings.OnCloseSettings.AddListener(() => element.Revert());
+        Settings.OnApplySettings.AddListener(() => element.Apply());
+
+        element.Label.text = label;
+
+        if (element.Placeholder != null)
+            element.Placeholder.text = placeholder;
+
+        element.InputField.SetTextWithoutNotify(value);
+        element.Apply();
+        element.Root.gameObject.SetActive(true);
+
+        PushElement(element);
+        return element;
+    }
+
     private void PushElement(BaseAtlyssElement element)
     {
         ContentElements.Add(element);

--- a/EasySettings/TemplateManager.cs
+++ b/EasySettings/TemplateManager.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using Nessie.ATLYSS.EasySettings.UIElements;
+﻿using Nessie.ATLYSS.EasySettings.UIElements;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -17,6 +17,7 @@ internal static class TemplateManager
     internal static AtlyssAdvancedSlider AdvancedSliderTemplate;
     internal static AtlyssDropdown DropdownTemplate;
     internal static AtlyssKeyButton KeyButtonTemplate;
+    internal static AtlyssTextField TextFieldTemplate;
 
     #region Initialization
 
@@ -47,6 +48,13 @@ internal static class TemplateManager
         modTab.Content = (RectTransform)modTabElement.GetComponentInChildren<VerticalLayoutGroup>().transform;
 
         InitializeTabContent(modTab.Content);
+
+        RectTransform textFieldRoot = FindTextField(manager);
+        if (textFieldRoot)
+        {
+            TextFieldTemplate = CreateTextField(modTab.Content, textFieldRoot);
+            TextFieldTemplate.Root.gameObject.SetActive(false);
+        }
 
         RectTransform spaceRoot = FindSpace(manager);
         if (spaceRoot)
@@ -116,6 +124,23 @@ internal static class TemplateManager
     private static RectTransform[] GetVanillaTabs(SettingsManager manager)
     {
         return [manager._videoTabContent, manager._audioTabContent, manager._inputTabContent, manager._networkTabContent];
+    }
+
+    private static RectTransform FindTextField(SettingsManager manager)
+    {
+        RectTransform[] tabContents = GetVanillaTabs(manager);
+
+        InputField inputField = manager._defaultChatRoomNameInput;
+        Text labelText = inputField.GetComponentInChildren<Text>(true);
+
+        if (!Utility.TryGetElementRoot(tabContents, inputField.transform, out Transform root))
+            return null;
+
+        List<Component> compRefs = root.gameObject.AddComponent<ComponentReferences>().components;
+        compRefs.Add(inputField);
+        compRefs.Add(labelText);
+
+        return (RectTransform)root;
     }
 
     private static RectTransform FindSpace(SettingsManager manager)
@@ -456,5 +481,40 @@ internal static class TemplateManager
         AtlyssSpace space = new AtlyssSpace { Root = root };
 
         return space;
+    }
+
+    internal static AtlyssTextField CreateTextField(RectTransform container) => CreateTextField(container, TextFieldTemplate);
+
+    internal static AtlyssTextField CreateTextField(RectTransform container, AtlyssTextField template) => CreateTextField(container, template.Root);
+
+    internal static AtlyssTextField CreateTextField(RectTransform container, RectTransform template)
+    {
+        RectTransform root = Object.Instantiate(template, container);
+
+        List<Component> components = root.GetComponentInChildren<ComponentReferences>(true).components;
+
+        AtlyssTextField textField = new AtlyssTextField
+        {
+            Root = root,
+            Label = root.GetComponentsInChildren<Text>(true)[2],
+            Placeholder = root.GetComponentsInChildren<Text>(true)[0],
+            InputField = (InputField)components[0]
+        };
+
+        textField.Root.GetComponentsInChildren<Text>(true)[3].gameObject.SetActive(false); // hashtag symbol next to text field
+
+        textField.Root.GetComponentsInChildren<Text>(true)[1].color = Color.white; // Input field text color
+        textField.Root.GetComponentsInChildren<Text>(true)[2].color = Color.white; // Label text color
+
+        var currColors = textField.InputField.colors;
+
+        currColors.normalColor = new Color(0.7843f, 0.7843f, 0.7843f, 1f);
+
+        textField.InputField.colors = currColors;
+        textField.InputField.characterLimit = 32;
+
+        textField.Initialize();
+
+        return textField;
     }
 }

--- a/EasySettings/TemplateManager.cs
+++ b/EasySettings/TemplateManager.cs
@@ -131,14 +131,12 @@ internal static class TemplateManager
         RectTransform[] tabContents = GetVanillaTabs(manager);
 
         InputField inputField = manager._defaultChatRoomNameInput;
-        Text labelText = inputField.GetComponentInChildren<Text>(true);
 
         if (!Utility.TryGetElementRoot(tabContents, inputField.transform, out Transform root))
             return null;
 
         List<Component> compRefs = root.gameObject.AddComponent<ComponentReferences>().components;
         compRefs.Add(inputField);
-        compRefs.Add(labelText);
 
         return (RectTransform)root;
     }
@@ -492,20 +490,19 @@ internal static class TemplateManager
         RectTransform root = Object.Instantiate(template, container);
 
         List<Component> components = root.GetComponentInChildren<ComponentReferences>(true).components;
+        Text[] textComponents = root.GetComponentsInChildren<Text>(true);
 
         AtlyssTextField textField = new AtlyssTextField
         {
             Root = root,
-            Label = root.GetComponentsInChildren<Text>(true)[2], // couldnt get it to work with components[1]
-            Placeholder = ((InputField)components[0]).placeholder as Text,
+            Label = textComponents[2],
+            Placeholder = textComponents[0],
             InputField = (InputField)components[0],
         };
 
-        var textComponents = textField.Root.GetComponentsInChildren<Text>(true);
-
-        textComponents[0].color = Color.gray;  // Placeholder text color
-        textComponents[1].color = Color.white; // Input field text color
-        textComponents[2].color = Color.white; // Label text color
+        textField.Placeholder.color = Color.gray;
+        textField.InputField.textComponent.color = Color.white;
+        textField.Label.color = Color.white;
 
         Object.Destroy(textComponents[3].gameObject); // hashtag symbol next to text field, destroy it last
 

--- a/EasySettings/TemplateManager.cs
+++ b/EasySettings/TemplateManager.cs
@@ -496,21 +496,23 @@ internal static class TemplateManager
         AtlyssTextField textField = new AtlyssTextField
         {
             Root = root,
-            Label = root.GetComponentsInChildren<Text>(true)[2],
-            Placeholder = root.GetComponentsInChildren<Text>(true)[0],
-            InputField = (InputField)components[0]
+            Label = root.GetComponentsInChildren<Text>(true)[2], // couldnt get it to work with components[1]
+            Placeholder = ((InputField)components[0]).placeholder as Text,
+            InputField = (InputField)components[0],
         };
 
-        textField.Root.GetComponentsInChildren<Text>(true)[3].gameObject.SetActive(false); // hashtag symbol next to text field
+        var textComponents = textField.Root.GetComponentsInChildren<Text>(true);
 
-        textField.Root.GetComponentsInChildren<Text>(true)[1].color = Color.white; // Input field text color
-        textField.Root.GetComponentsInChildren<Text>(true)[2].color = Color.white; // Label text color
+        textComponents[0].color = Color.gray;  // Placeholder text color
+        textComponents[1].color = Color.white; // Input field text color
+        textComponents[2].color = Color.white; // Label text color
 
-        var currColors = textField.InputField.colors;
+        Object.Destroy(textComponents[3].gameObject); // hashtag symbol next to text field, destroy it last
 
+        ColorBlock currColors = textField.InputField.colors;
         currColors.normalColor = new Color(0.7843f, 0.7843f, 0.7843f, 1f);
-
         textField.InputField.colors = currColors;
+        
         textField.InputField.characterLimit = 32;
 
         textField.Initialize();


### PR DESCRIPTION
i added a ```AtlyssTextField``` element so we can have actual text input in settings. works like the other elements (toggles, sliders, etc.) but lets you type a string. you can also pass in a placeholder (defaults to "placeholder").

uses the ```_defaultChatRoomNameInput``` as the template.

hooked it into ```OnApplySettings``` and ```OnCloseSettings``` so it behaves the same way as the rest. shouldn’t break anything old.