### PR TITLE
Allow creating custom tabs for settings

### DIFF
--- a/EasySettings/EasySettingsPlugin.cs
+++ b/EasySettings/EasySettingsPlugin.cs
@@ -24,7 +24,6 @@ public class EasySettingsPlugin : BaseUnityPlugin
                 return;
             }
 
-            AddModTabBottomSpace();
             Settings.OnInitialized.Invoke();
         });
     }
@@ -42,10 +41,5 @@ public class EasySettingsPlugin : BaseUnityPlugin
         modTab.OnClicked.AddListener(() => { SettingsManager._current.Set_SettingMenuSelectionIndex(Settings.ModTabIndex); });
         Settings.ModTab.TabButton = modTab;
         return true;
-    }
-
-    private void AddModTabBottomSpace()
-    {
-        Settings.ModTab.BottomSpace = Settings.ModTab.AddSpace();
     }
 }

--- a/EasySettings/Patches/SettingsPatches.cs
+++ b/EasySettings/Patches/SettingsPatches.cs
@@ -111,7 +111,7 @@ public static class SettingsPatches
         // ReSharper disable once UnusedMember.Local
         // ReSharper disable InconsistentNaming
         [HarmonyPostfix]
-        private static void ApplySelection(SettingsManager __instance) // ReSharper restore InconsistentNaming
+        private static void ApplySelection() // ReSharper restore InconsistentNaming
         {
             Settings.UpdateTabVisibility();
         }

--- a/EasySettings/Patches/SettingsPatches.cs
+++ b/EasySettings/Patches/SettingsPatches.cs
@@ -74,6 +74,7 @@ public static class SettingsPatches
             }
 
             TemplateManager.Initialize();
+            TemplateManager.InitializeTabContent(Settings.ModTab);
 
             OnSettingsMenuInitialized.Invoke();
         }
@@ -112,15 +113,7 @@ public static class SettingsPatches
         [HarmonyPostfix]
         private static void ApplySelection(SettingsManager __instance) // ReSharper restore InconsistentNaming
         {
-            if (ModTab.Element)
-            {
-                ModTab.Element.isEnabled = (int)__instance._currentSettingsMenuSelection == Settings.ModTabIndex;
-            }
-
-            if (ModTab.Content)
-            {
-                ModTab.Content.anchoredPosition = Vector2.zero;
-            }
+            Settings.UpdateTabVisibility();
         }
     }
 

--- a/EasySettings/Prefabs/TabSelectorPrefab.cs
+++ b/EasySettings/Prefabs/TabSelectorPrefab.cs
@@ -1,0 +1,140 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Nessie.ATLYSS.EasySettings.Prefabs;
+
+internal static class TabSelectorPrefab
+{
+    private const string FONT_PATH = "_graphic/_font/terminal-grotesque";
+    private const string BACKGROUND_SPRITE_PATH = "_graphic/_ui/bk_04";
+    private const string INDICATOR_SPRITE_PATH = "_graphic/_ui/uiSprite_playerIndicator";
+
+    internal static RectTransform Create()
+    {
+        GameObject obj = CreateRoot(out Button leftButton, out Button rightButton, out Text label);
+
+        List<Component> compRefs = obj.AddComponent<ComponentReferences>().components;
+        compRefs.Add(leftButton);
+        compRefs.Add(rightButton);
+        compRefs.Add(label);
+
+        return obj.transform as RectTransform;
+    }
+    
+    private static GameObject CreateRoot(out Button leftButton, out Button rightButton, out Text label)
+    {
+        GameObject obj = new("EasySettings TabSelector");
+
+        RectTransform rectTransform = obj.AddComponent<RectTransform>();
+        rectTransform.pivot = new Vector2(0.5f, 0.5f);
+        rectTransform.anchorMin = new Vector2(0, 1);
+        rectTransform.anchorMax = new Vector2(0, 1);
+        rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 545);
+        rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 30);
+
+        CanvasRenderer canvasRenderer = obj.AddComponent<CanvasRenderer>();
+        canvasRenderer.cullTransparentMesh = true;
+
+        Image image = obj.AddComponent<Image>();
+        image.color = new Color(0.75f, 0.75f, 1f);
+        image.raycastTarget = true;
+        image.maskable = true;
+        image.sprite = Resources.Load<Sprite>(BACKGROUND_SPRITE_PATH);
+        image.type = Image.Type.Sliced;
+        image.fillCenter = true;
+        image.fillMethod = Image.FillMethod.Radial360;
+        image.fillAmount = 1;
+        image.fillClockwise = true;
+        image.pixelsPerUnitMultiplier = 1;
+
+        CreateButton(obj, out leftButton, true);
+        CreateLabel(obj, out label);
+        CreateButton(obj, out rightButton, false);
+
+        return obj;
+    }
+
+    private static GameObject CreateButton(GameObject root, out Button button, bool isLeftOriented)
+    {
+        GameObject obj = new("Button");
+        obj.transform.SetParent(root.transform);
+
+        RectTransform rectTransform = obj.AddComponent<RectTransform>();
+        rectTransform.pivot = new Vector2(0.5f, 0.5f);
+        rectTransform.anchorMin = new Vector2(0.5f, 0.5f);
+        rectTransform.anchorMax = new Vector2(0.5f, 0.5f);
+        rectTransform.SetInsetAndSizeFromParentEdge(isLeftOriented ? RectTransform.Edge.Left : RectTransform.Edge.Right, 6, 30);
+        rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 30);
+        rectTransform.localRotation = Quaternion.Euler(0, 0, isLeftOriented ? -90 : 90); // Sprite normally points downward
+
+        CanvasRenderer canvasRenderer = obj.AddComponent<CanvasRenderer>();
+        canvasRenderer.cullTransparentMesh = true;
+        
+        Image image = obj.AddComponent<Image>();
+        image.color = Color.white;
+        image.raycastTarget = true;
+        image.maskable = true;
+        image.sprite = Resources.Load<Sprite>(INDICATOR_SPRITE_PATH);
+        image.type = Image.Type.Filled;
+        image.fillCenter = true;
+        image.fillMethod = Image.FillMethod.Radial360;
+        image.fillAmount = 1;
+        image.fillClockwise = true;
+        image.pixelsPerUnitMultiplier = 1;
+
+        button = obj.AddComponent<Button>();
+        button.transition = Selectable.Transition.ColorTint;
+        button.colors = new ColorBlock
+        {
+            normalColor = Color.white,
+            highlightedColor = new Color(0.9607f, 0.9607f, 0.9607f),
+            pressedColor = new Color(0.78431f, 0.78431f, 0.78431f),
+            selectedColor = new Color(0.9607f, 0.9607f, 0.9607f),
+            disabledColor = new Color(0.78431f, 0.78431f, 0.78431f),
+            colorMultiplier = 1f,
+            fadeDuration = 0.1f,
+        };
+        button.animationTriggers.normalTrigger = "Normal";
+        button.animationTriggers.highlightedTrigger = "Highlighted";
+        button.animationTriggers.pressedTrigger = "Pressed";
+        button.animationTriggers.selectedTrigger = "Selected";
+        button.animationTriggers.disabledTrigger = "Disabled";
+        button.targetGraphic = image;
+
+        return obj;
+    }
+    
+    private static GameObject CreateLabel(GameObject root, out Text label)
+    {
+        GameObject obj = new("Label");
+        obj.transform.SetParent(root.transform);
+
+        RectTransform rectTransform = obj.AddComponent<RectTransform>();
+        rectTransform.pivot = new Vector2(0.5f, 0.5f);
+        rectTransform.anchorMin = new Vector2(0.5f, 0.5f);
+        rectTransform.anchorMax = new Vector2(0.5f, 0.5f);
+        rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 420);
+        rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 30);
+
+        CanvasRenderer canvasRenderer = obj.AddComponent<CanvasRenderer>();
+        canvasRenderer.cullTransparentMesh = true;
+
+        Text text = label = obj.AddComponent<Text>();
+        text.color = Color.white;
+        text.maskable = true;
+        text.font = Resources.Load<Font>(FONT_PATH);
+        text.fontSize = 22;
+        text.fontStyle = FontStyle.Normal;
+        text.resizeTextMinSize = 10;
+        text.resizeTextMaxSize = 40;
+        text.alignment = TextAnchor.MiddleCenter;
+        text.supportRichText = true;
+        text.horizontalOverflow = HorizontalWrapMode.Wrap;
+        text.verticalOverflow = VerticalWrapMode.Truncate;
+        text.lineSpacing = 1;
+        text.text = "Label";
+
+        return obj;
+    }
+}

--- a/EasySettings/Prefabs/TabSelectorPrefab.cs
+++ b/EasySettings/Prefabs/TabSelectorPrefab.cs
@@ -21,17 +21,17 @@ internal static class TabSelectorPrefab
 
         return obj.transform as RectTransform;
     }
-    
+
     private static GameObject CreateRoot(out Button leftButton, out Button rightButton, out Text label)
     {
         GameObject obj = new("EasySettings TabSelector");
 
         RectTransform rectTransform = obj.AddComponent<RectTransform>();
         rectTransform.pivot = new Vector2(0.5f, 0.5f);
-        rectTransform.anchorMin = new Vector2(0, 1);
-        rectTransform.anchorMax = new Vector2(0, 1);
-        rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 545);
-        rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 30);
+        rectTransform.anchorMin = new Vector2(0f, 1f);
+        rectTransform.anchorMax = new Vector2(0f, 1f);
+        rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 545f);
+        rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 30f);
 
         CanvasRenderer canvasRenderer = obj.AddComponent<CanvasRenderer>();
         canvasRenderer.cullTransparentMesh = true;
@@ -44,9 +44,9 @@ internal static class TabSelectorPrefab
         image.type = Image.Type.Sliced;
         image.fillCenter = true;
         image.fillMethod = Image.FillMethod.Radial360;
-        image.fillAmount = 1;
+        image.fillAmount = 1f;
         image.fillClockwise = true;
-        image.pixelsPerUnitMultiplier = 1;
+        image.pixelsPerUnitMultiplier = 1f;
 
         CreateButton(obj, out leftButton, true);
         CreateLabel(obj, out label);
@@ -64,13 +64,13 @@ internal static class TabSelectorPrefab
         rectTransform.pivot = new Vector2(0.5f, 0.5f);
         rectTransform.anchorMin = new Vector2(0.5f, 0.5f);
         rectTransform.anchorMax = new Vector2(0.5f, 0.5f);
-        rectTransform.SetInsetAndSizeFromParentEdge(isLeftOriented ? RectTransform.Edge.Left : RectTransform.Edge.Right, 6, 30);
-        rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 30);
-        rectTransform.localRotation = Quaternion.Euler(0, 0, isLeftOriented ? -90 : 90); // Sprite normally points downward
+        rectTransform.SetInsetAndSizeFromParentEdge(isLeftOriented ? RectTransform.Edge.Left : RectTransform.Edge.Right, 6f, 30f);
+        rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 30f);
+        rectTransform.localRotation = Quaternion.Euler(0f, 0f, isLeftOriented ? -90f : 90f); // Sprite normally points downward
 
         CanvasRenderer canvasRenderer = obj.AddComponent<CanvasRenderer>();
         canvasRenderer.cullTransparentMesh = true;
-        
+
         Image image = obj.AddComponent<Image>();
         image.color = Color.white;
         image.raycastTarget = true;
@@ -79,9 +79,9 @@ internal static class TabSelectorPrefab
         image.type = Image.Type.Filled;
         image.fillCenter = true;
         image.fillMethod = Image.FillMethod.Radial360;
-        image.fillAmount = 1;
+        image.fillAmount = 1f;
         image.fillClockwise = true;
-        image.pixelsPerUnitMultiplier = 1;
+        image.pixelsPerUnitMultiplier = 1f;
 
         button = obj.AddComponent<Button>();
         button.transition = Selectable.Transition.ColorTint;
@@ -104,7 +104,7 @@ internal static class TabSelectorPrefab
 
         return obj;
     }
-    
+
     private static GameObject CreateLabel(GameObject root, out Text label)
     {
         GameObject obj = new("Label");
@@ -114,8 +114,8 @@ internal static class TabSelectorPrefab
         rectTransform.pivot = new Vector2(0.5f, 0.5f);
         rectTransform.anchorMin = new Vector2(0.5f, 0.5f);
         rectTransform.anchorMax = new Vector2(0.5f, 0.5f);
-        rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 420);
-        rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 30);
+        rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 420f);
+        rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 30f);
 
         CanvasRenderer canvasRenderer = obj.AddComponent<CanvasRenderer>();
         canvasRenderer.cullTransparentMesh = true;

--- a/EasySettings/Settings.cs
+++ b/EasySettings/Settings.cs
@@ -34,7 +34,7 @@ public static class Settings
     public static UnityEvent OnCloseSettings { get; } = new();
 
     internal static int ModTabIndex { get; set; }
-    internal static int SettingsTabIndex { get; set; } = 0;
+    internal static int SettingsTabIndex { get; set; }
     internal static List<SettingsTab> SettingsTabs { get; } = [ModTab];
 
     /// <summary>
@@ -44,31 +44,38 @@ public static class Settings
     /// <returns>A new tab you can use for organizing settings</returns>
     public static SettingsTab AddCustomTab(string label)
     {
-        SettingsTab tab = new SettingsTab
+        SettingsTab tab = new()
         {
-            TabName = label
+            TabName = label,
         };
-        
+
         SettingsTabs.Add(tab);
         SettingsTabs.Sort((first, second) =>
         {
             if (first == ModTab)
+            {
                 return -1;
-            
+            }
+
             if (second == ModTab)
+            {
                 return 1;
+            }
 
             return string.Compare(first.TabName, second.TabName, StringComparison.Ordinal);
         });
+
         SettingsTabIndex = 0;
         TemplateManager.InitializeTabContent(tab);
 
         for (int i = 0; i < SettingsTabs.Count; i++)
+        {
             SettingsTabs[i].TabControlLabel.text = $"{SettingsTabs[i].TabName} ({i + 1} / {SettingsTabs.Count})";
+        }
 
         return tab;
     }
-    
+
     internal static AtlyssTabButton AddTabButton(string label)
     {
         SettingsManager manager = SettingsManager._current;
@@ -83,17 +90,21 @@ public static class Settings
 
     internal static void UpdateTabVisibility()
     {
-        bool currentlyOnModTab = (int)SettingsManager._current._currentSettingsMenuSelection == Settings.ModTabIndex;
-        
+        bool currentlyOnModTab = (int)SettingsManager._current._currentSettingsMenuSelection == ModTabIndex;
+
         for (int i = 0; i < SettingsTabs.Count; i++)
         {
-            var tab = SettingsTabs[i];
-            
+            SettingsTab tab = SettingsTabs[i];
+
             if (tab.Element)
-                tab.Element.isEnabled = currentlyOnModTab && i == Settings.SettingsTabIndex;
-            
+            {
+                tab.Element.isEnabled = currentlyOnModTab && i == SettingsTabIndex;
+            }
+
             if (tab.Content)
+            {
                 tab.Content.anchoredPosition = Vector2.zero;
+            }
         }
     }
 }

--- a/EasySettings/SettingsTab.cs
+++ b/EasySettings/SettingsTab.cs
@@ -8,6 +8,7 @@ using Nessie.ATLYSS.EasySettings.Extensions;
 using Nessie.ATLYSS.EasySettings.UIElements;
 using UnityEngine;
 using UnityEngine.Events;
+using UnityEngine.UI;
 
 namespace Nessie.ATLYSS.EasySettings;
 
@@ -21,8 +22,10 @@ public class SettingsTab
     public MenuElement Element;
     public RectTransform Content;
     public List<BaseAtlyssElement> ContentElements = new();
+    public string TabName = "General";
 
     internal AtlyssSpace BottomSpace;
+    internal Text TabControlLabel;
 
     internal static Dictionary<int, AtlyssKeyButton> KeyButtonIndexToKeyButton = new();
 

--- a/EasySettings/TemplateManager.cs
+++ b/EasySettings/TemplateManager.cs
@@ -46,7 +46,7 @@ internal static class TemplateManager
         TextFieldTemplate = TextFieldPrefab.Create();
         Object.DontDestroyOnLoad(TextFieldTemplate);
         TextFieldTemplate.gameObject.SetActive(false);
-        
+
         TabSelectorTemplate = TabSelectorPrefab.Create();
         Object.DontDestroyOnLoad(TabSelectorTemplate);
         TabSelectorTemplate.gameObject.SetActive(false);
@@ -77,29 +77,35 @@ internal static class TemplateManager
 
         RectTransform tabSelector = Object.Instantiate(TabSelectorTemplate, settingsTab.Content);
         tabSelector.gameObject.SetActive(true);
-        var components = tabSelector.GetComponent<ComponentReferences>();
-        var leftButton = (Button)components.components[0];
-        var rightButton = (Button)components.components[1];
-        var label = (Text)components.components[2];
+        ComponentReferences components = tabSelector.GetComponent<ComponentReferences>();
+        Button leftButton = (Button)components.components[0];
+        Button rightButton = (Button)components.components[1];
+        Text label = (Text)components.components[2];
 
         settingsTab.TabControlLabel = label;
-        
+
         leftButton.onClick.AddListener(() =>
         {
             Settings.SettingsTabIndex--;
             if (Settings.SettingsTabIndex < 0)
+            {
                 Settings.SettingsTabIndex = Settings.SettingsTabs.Count - 1;
+            }
             Settings.UpdateTabVisibility();
             SettingsManager._current._gamepadSelectAsrc.Play();
         });
+
         rightButton.onClick.AddListener(() =>
         {
             Settings.SettingsTabIndex++;
             if (Settings.SettingsTabIndex >= Settings.SettingsTabs.Count)
+            {
                 Settings.SettingsTabIndex = 0;
+            }
             Settings.UpdateTabVisibility();
             SettingsManager._current._gamepadSelectAsrc.Play();
         });
+
         label.text = settingsTab.TabName;
     }
 
@@ -124,6 +130,7 @@ internal static class TemplateManager
             foreach (RectTransform child in tab)
             {
                 if (child.childCount != 0) continue;
+
                 Component[] components = child.GetComponents<Component>();
                 if (components.Length > 1) continue;
 
@@ -265,8 +272,10 @@ internal static class TemplateManager
     internal static RectTransform CreateHiddenClone(RectTransform transform)
     {
         if (transform == null)
+        {
             return null;
-        
+        }
+
         RectTransform root = Object.Instantiate(transform, null);
         root.gameObject.SetActive(false);
         Object.DontDestroyOnLoad(root);
@@ -494,6 +503,6 @@ internal static class TemplateManager
 
         return textField;
     }
-    
+
     #endregion
 }


### PR DESCRIPTION
Allows modders to create new tabs using the new `Settings.AddCustomTab(name)` API. This is mainly to allow organizing settings a bit and reduce clutter when using mods that declare a lot of options.

The custom tabs act the same as the previous main tab in terms of mod controls. Tabs can have names and are ordered based on that name, so that users can more intuitively navigate to a given tab. Each tab gets an implicit tab selector control at the top that allows changing between custom tabs, and shows the current tab name, the current tab's number, the total number of tabs, and has a left / right button for doing the actual switching.

The current main tab is now called "General", and will always be sorted first compared to custom tabs. Mods that were built against previous ES versions will put their settings in here due to using `Settings.ModTab`. Mods that are built against the new version can choose to separate their settings into one or more custom tabs, like this:

```cs
var tab = Settings.AddCustomTab("ModAudio");
tab.AddButton("Enabled", EnabledConfig);

var audioPacksTab = Settings.AddCustomTab("ModAudio audio packs");
audioPacksTab.AddButton("AtlyssRemixEnabled", AtlyssRemixEnabledConfig);
```

<img width="1088" height="881" alt="image" src="https://github.com/user-attachments/assets/9d80a058-784f-4a6d-b10b-6b7f9a133efe" />
